### PR TITLE
Bump up version to 1.1.0

### DIFF
--- a/extension/package/manifest.json
+++ b/extension/package/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "VectorDrawable Previewer",
   "description": "This extension can preview the vector drawable when you open it",
-  "version" : "1.0.0",
+  "version" : "1.1.0",
   "author": "Jumpei Matsuda @jmatsu",
   "icons": { "16": "icon_16.png",
              "48": "icon_48.png",


### PR DESCRIPTION
- Enable previews vector drawables which contain comments
- Fixed GitHub previews didn't work due to GitHub's HTML contents' changes